### PR TITLE
Fixes shared attributes at run time

### DIFF
--- a/Bright Tides/Assets/Prefabs/Entities/Enemy/Brigantine.prefab
+++ b/Bright Tides/Assets/Prefabs/Entities/Enemy/Brigantine.prefab
@@ -343,4 +343,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 46d776efb61540044a27d64728beb89e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  attributesTemplate: {fileID: 11400000, guid: 165b127edfedea441a7aca9d9e212611, type: 2}
   attributes: {fileID: 0}

--- a/Bright Tides/Assets/Prefabs/Entities/Enemy/Sloop.prefab
+++ b/Bright Tides/Assets/Prefabs/Entities/Enemy/Sloop.prefab
@@ -1425,4 +1425,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 46d776efb61540044a27d64728beb89e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  attributesTemplate: {fileID: 11400000, guid: e288f5419da8e33499d6fa4f91887150, type: 2}
   attributes: {fileID: 0}

--- a/Bright Tides/Assets/Prefabs/Entities/Enemy/Warship.prefab
+++ b/Bright Tides/Assets/Prefabs/Entities/Enemy/Warship.prefab
@@ -124,4 +124,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 46d776efb61540044a27d64728beb89e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  attributesTemplate: {fileID: 11400000, guid: 42fd2e5f7f17f1e4c921c4c25dc8a737, type: 2}
   attributes: {fileID: 0}

--- a/Bright Tides/Assets/Prefabs/Entities/Player/PlayerShip.prefab
+++ b/Bright Tides/Assets/Prefabs/Entities/Player/PlayerShip.prefab
@@ -343,4 +343,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 46d776efb61540044a27d64728beb89e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  attributesTemplate: {fileID: 11400000, guid: 7d250f369273c384c9832bc212f7d35a, type: 2}
   attributes: {fileID: 11400000, guid: 7d250f369273c384c9832bc212f7d35a, type: 2}

--- a/Bright Tides/Assets/Resources/Entities/PirateLevel1.asset
+++ b/Bright Tides/Assets/Resources/Entities/PirateLevel1.asset
@@ -16,13 +16,14 @@ MonoBehaviour:
   captainName: Capatin Bob
   level: 0
   experience: 0
-  health: 100
+  health: 10
   ammo: 0
-  gold: 0
+  gold: 25
   actionsPerTurn: 0
   actionsRemaining: 0
   movementSpeed: 0
   baseAttackRange: 0
+  baseAttackDamage: 0
   strength: 0
   agility: 0
   dexterity: 0

--- a/Bright Tides/Assets/Resources/Entities/PirateLevel2.asset
+++ b/Bright Tides/Assets/Resources/Entities/PirateLevel2.asset
@@ -16,9 +16,9 @@ MonoBehaviour:
   captainName: 
   level: 0
   experience: 0
-  health: 0
+  health: 20
   ammo: 0
-  gold: 0
+  gold: 50
   actionsPerTurn: 0
   actionsRemaining: 0
   movementSpeed: 0

--- a/Bright Tides/Assets/Resources/Entities/PirateLevel3.asset
+++ b/Bright Tides/Assets/Resources/Entities/PirateLevel3.asset
@@ -16,9 +16,9 @@ MonoBehaviour:
   captainName: 
   level: 0
   experience: 50
-  health: 15
+  health: 30
   ammo: 0
-  gold: 0
+  gold: 100
   actionsPerTurn: 0
   actionsRemaining: 0
   movementSpeed: 0

--- a/Bright Tides/Assets/Resources/Entities/Player.asset
+++ b/Bright Tides/Assets/Resources/Entities/Player.asset
@@ -17,12 +17,13 @@ MonoBehaviour:
   level: 1
   experience: 0
   health: 100
-  ammo: 20
+  ammo: 30
   gold: 0
-  actionsPerTurn: 2
-  actionsRemaining: 2
+  actionsPerTurn: 5
+  actionsRemaining: 5
   movementSpeed: 1
   baseAttackRange: 1
+  baseAttackDamage: 5
   strength: 0
   agility: 0
   dexterity: 0

--- a/Bright Tides/Assets/Scripts/Entities/Entity.cs
+++ b/Bright Tides/Assets/Scripts/Entities/Entity.cs
@@ -3,5 +3,29 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class Entity : MonoBehaviour {
+	private EntityAttributes attributesTemplate;
+
+	public EntityAttributes AttributesTemplate
+	{
+		get { return this.attributesTemplate; }
+		set
+		{
+			attributesTemplate = value;
+			if (attributesTemplate != null)
+			{
+				attributes = ScriptableObject.Instantiate(attributesTemplate);
+			}
+		}
+	}
+
 	public EntityAttributes attributes;
+
+	private void Awake()
+	{
+		Debug.Log("Setting attributes for " + gameObject.name);
+		if (attributesTemplate != null)
+		{
+			attributes = ScriptableObject.Instantiate(attributesTemplate);
+		}
+	}
 }

--- a/Bright Tides/Assets/Scripts/Managers/EntityGenerator.cs
+++ b/Bright Tides/Assets/Scripts/Managers/EntityGenerator.cs
@@ -53,7 +53,7 @@ public class EntityGenerator {
 
                         if (treasureCount > 0) {
                             EntityAttributes selectedAttributes = entitySet.GetEntityAttributesForType(type);
-                            Entity entityInstance = entitySet.CreateEntity(selectedAttributes); // Create the entity at the given tile
+                            Entity entityInstance = ScriptableObject.Instantiate(entitySet.CreateEntity(selectedAttributes)); // Create the entity at the given tile
                             spawn.SetTileAsParent(entityInstance); // Set the tile as the parent along with any side-effects
                             treasureCount--; // Reduce the treasures left to spawn
                         }

--- a/Bright Tides/Assets/Scripts/Managers/GameManager.cs
+++ b/Bright Tides/Assets/Scripts/Managers/GameManager.cs
@@ -27,6 +27,7 @@ public class GameManager : MonoBehaviour {
     [Header("Player Settings")]
     public GameObject playerModel;
     public GameObject playerInstance;
+	public EntityAttributes playerAttributesTemplates;
 	
     public float movementSpeed = 0.5f;
 
@@ -151,6 +152,7 @@ public class GameManager : MonoBehaviour {
 		if (playerInstance == null )
 		{
 			playerInstance = Instantiate(playerModel, startingTileTransform);
+			playerInstance.GetComponent<Entity>().AttributesTemplate = ScriptableObject.Instantiate(GameManager.instance.playerAttributesTemplates);
 			playerInstance.name = "Player";
 		}
 		else

--- a/Bright Tides/Assets/Scripts/Scriptables/EntitySet.cs
+++ b/Bright Tides/Assets/Scripts/Scriptables/EntitySet.cs
@@ -39,10 +39,13 @@ public class EntitySet : ScriptableObject {
     public Entity CreateEntity(EntityAttributes entityAttributes) {
         GameObject entityInstance = Instantiate(entityAttributes.model); // Create an entity using the selected model
         Entity entityComponent = entityInstance.GetComponent<Entity>();
-        if (!entityComponent) {
+		
+		if (!entityComponent) {
             entityComponent = entityInstance.AddComponent(typeof(Entity)) as Entity; // Create the entity instance component if it does not already exist on the prefab
         }
-        entityComponent.attributes = entityAttributes; // Apply the attributes to the entity
-        return entityComponent;
+
+		entityComponent.AttributesTemplate = entityAttributes; // Apply the attributes to the entity
+
+		return entityComponent;
     }
 }


### PR DESCRIPTION
Without these changes, all spawns based on a particular ScriptableObject share the defined attributes at run-time.  For example, if two level 1 pirate ships are on the map, they share the same health.

These changes resolve this issue and instantiate clones of the entity attribute defined by AttributesTemplate